### PR TITLE
[SGP-21988] Support additional periodic task configuration via @periodic_task

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -204,6 +204,7 @@ class ModelEntry(ScheduleEntry):
             'priority': priority,
             'headers': dumps(headers or {}),
             'expire_seconds': expire_seconds,
+            **kwargs,
         }
 
     def __repr__(self):

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ commands =
     # must use older versions for starting with older celery-beat
     pip install "django>=1.11.17,<2.0"
     pip install "django-timezone-field<4.0"
-    pip install "celery<5.0.0"
+    pip install "celery~=5.0.0"
     pip list
     # run the migration for the older version
     python manage.py migrate django_celery_beat
@@ -78,7 +78,7 @@ commands =
     # must use older versions for starting with older celery-beat
     pip install "django>=1.11.17,<2.0"
     pip install "django-timezone-field<4.0"
-    pip install "celery<5.0.0"
+    pip install "celery~=5.0.0"
     pip list
     # run the migration for the older version
     python manage.py migrate django_celery_beat


### PR DESCRIPTION
This PR updates the `@periodic_task` decorator to accept an additional (optional) parameter, `periodic_task_opts`.

`periodic_task_opts` is a dict of options which will be used to configure the periodic task that gets created, eg. to set the `description` or `start_time`: https://django-celery-beat.readthedocs.io/en/latest/reference/django-celery-beat.models.html#django_celery_beat.models.PeriodicTask

## DevQA

1. Install this branch into an app env.
2. Create a task using the `@periodic_task` decorator, and include options to configure the periodic task. Also include options to configure the celery task. For example:
```
@periodic_task(
    name="my task name",
    run_every=(datetime.timedelta(minutes=1)),
    periodic_task_opts={
        "description": "my task description",
    }
    time_limit=5,
)
def my_task_function(...):
   ...
```
3. Run the app and celery beat. Check in the DB or in a Django shell that the periodic task options were applied correctly, eg.
```
In [1]: from django_celery_beat.models import PeriodicTask

In [2]: PeriodicTask.objects.get(name="my task name").description
Out[3]: 'my task description'
```
4. Check in a Django shell that the task options were applied correctly, eg.
```
In [3]: from celery import current_app

In [4]: current_app.loader.import_default_modules()
Out[4]: [<module 'platform_project.lib.tasks' from '/app/platform_project/lib/tasks.py'>]

In [5]: current_app.tasks['my_task_function'].time_limit
Out[5]: 5
```