### PR TITLE
[IP-4767] Make it compatible with py39

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 case>=1.3.1
 pytest-django>=2.2,<4.0
-pytz>dev
+pytz>=2024.1
 pytest<4.0.0
 pytest-timeout
 ephem


### PR DESCRIPTION
This small change is required for this repo to be compatible with py39 as the notation "pytz>dev" is no longer supported a specific version number is required.